### PR TITLE
sysfs interface

### DIFF
--- a/README
+++ b/README
@@ -63,6 +63,7 @@ defined somewhere (often in the fec1 node or in fec2).
 		bus = <&mdio_bus>;
 		start-switch = <1>;
 		status = "okay";
+		soft-reset-gpios = <&gpio1 1 GPIO_ACTIVE_LOW>;
 
 		port@0 {
 			compatible = "ethernet-phy-id0022.1450";

--- a/README
+++ b/README
@@ -44,7 +44,34 @@ SMI mode to monitor and control the switch and PHYs.  The SMI simply spreads
 the switch register addresses across the register addresses of multiple PHY
 addresses on the MIIM bus.
 
-The driver should drop into the version 4.9 stable kernel without modification
+The driver should drop into the version 4.14 stable kernel without modification
 as this is what it was most recently tested against.  However, it was
 originally developed for 3.8; so it should also work reliably for everything
 between if you give some of the API calls (which changed) a little massaging.
+
+
+Example DTS fragment
+
+If `fec1` is connected to the P5 MAC interface physically, and `mdio_bus` is
+defined somewhere (often in the fec1 node or in fec2).
+
+	ksz8895 {
+		compatible = "microchip,ksz8895";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		bus = <&mdio_bus>;
+		start-switch = <1>;
+		status = "okay";
+
+		port@0 {
+			compatible = "ethernet-phy-id0022.1450";
+			reg = <0>;
+			label = "switch0";
+			ethernet = <&fec1>;
+			fixed-link {
+				speed = <100>;
+				full-duplex;
+			};
+		};
+	};

--- a/drivers/net/phy/ksz8895.c
+++ b/drivers/net/phy/ksz8895.c
@@ -1165,7 +1165,7 @@ static void ksz8895_free_data(struct ksz8895_data *data)
 static void ksz8895_reset(struct ksz8895_data *data) {
 	if (!data->reset)
 		return;
-	
+
 	gpiod_set_value(data->reset, 1);
 	mdelay(1);
 	gpiod_set_value(data->reset, 0);

--- a/drivers/net/phy/ksz8895_port.c
+++ b/drivers/net/phy/ksz8895_port.c
@@ -1,0 +1,392 @@
+/**
+ * port specific kobject management stuff, include directly in ksz8895.c
+ */
+
+/**
+ * @ksz8895 pointer to data object for ksz8895_* methods
+ * @id port id, 1-5
+ * @regbase base register address to use for control regs
+ */
+struct ksz8895_sysfs_port {
+	struct kobject kobj;
+	struct ksz8895_data *ksz8895;
+	uint8_t id;
+	u8 regbase;
+};
+
+#define to_ksz8895_sysfs_port(port) container_of(port, struct ksz8895_sysfs_port, kobj)
+
+struct ksz8895_port_attribute {
+	struct attribute attr;
+	ssize_t (*show)(struct ksz8895_sysfs_port *,
+	                struct ksz8895_port_attribute *,
+					char *);
+	ssize_t (*store)(struct ksz8895_sysfs_port *,
+	                 struct ksz8895_port_attribute *,
+					 const char *,
+					 size_t);
+};
+
+/* attribute that has a register offset to read/write embedded */
+struct ksz8895_port_control_attribute {
+	struct ksz8895_port_attribute attr;
+	u8 regoffset;
+};
+
+#define to_ksz8895_port_attribute(port) container_of(port, struct ksz8895_port_attribute, attr)
+#define to_ksz8895_port_control(port) \
+	container_of(port, struct ksz8895_port_control_attribute, attr)
+
+/* free memory associated with a port entry */
+static void ksz8895_port_release(struct kobject *kobj) {
+	struct ksz8895_sysfs_port *port = to_ksz8895_sysfs_port(kobj);
+	kfree(port);
+}
+
+static ssize_t ksz8895_port_show(struct kobject *kobj, struct attribute *attr, char *buf) {
+	struct ksz8895_sysfs_port *port = to_ksz8895_sysfs_port(kobj);
+	struct ksz8895_port_attribute *port_attr = to_ksz8895_port_attribute(attr);
+
+	if (!port_attr->show)
+		return -EIO;
+
+	return port_attr->show(port, port_attr, buf);
+}
+
+static ssize_t ksz8895_port_store(
+	struct kobject *kobj,
+	struct attribute *attr,
+	const char *buf,
+	size_t count)
+{
+	struct ksz8895_sysfs_port *port = to_ksz8895_sysfs_port(kobj);
+	struct ksz8895_port_attribute *port_attr = to_ksz8895_port_attribute(attr);
+
+	if (!port_attr->store)
+		return -EIO;
+
+	return port_attr->store(port, port_attr, buf, count);
+}
+
+static const struct sysfs_ops ksz8895_port_ops = {
+	.show = ksz8895_port_show,
+	.store = ksz8895_port_store,
+};
+
+static ssize_t port_vid_show(
+	struct ksz8895_sysfs_port *port,
+	struct ksz8895_port_attribute *attr,
+	char *buf)
+{
+	int result;
+	unsigned int vid = 0;
+
+	result = ksz8895_smi_read(port->ksz8895, port->regbase + 3);
+	if (result < 0)
+		return result;
+
+	vid |= (result & 0x0f) << 8;
+
+	result = ksz8895_smi_read(port->ksz8895, port->regbase + 4);
+	if (result < 0)
+		return result;
+
+	vid |= (result & 0xff);
+
+	return scnprintf(buf, PAGE_SIZE, "%d\n", vid);
+}
+
+static ssize_t port_vid_store(
+	struct ksz8895_sysfs_port *port,
+	struct ksz8895_port_attribute *attr,
+	const char *buf,
+	size_t count)
+{
+	unsigned int vid;
+	int ret;
+
+	ret = kstrtouint(buf, 10, &vid);
+	if (ret)
+		return ret;
+
+	if (vid > KSZ8895_MAXIMUM_VLAN_ID)
+		return -EINVAL;
+
+	/* don't clobber other bits */
+	ret = ksz8895_smi_modify(
+		port->ksz8895,
+		port->regbase + 3,
+		0x0f,
+		(u8) ((vid >> 8) & 0x0f)
+	);
+	if (ret)
+		return ret;
+
+	/* this is the whole register */
+	ret = ksz8895_smi_write(
+		port->ksz8895,
+		port->regbase + 4,
+		(u8) (vid & 0xff)
+	);
+	if (ret)
+		return ret;
+
+	return count;
+}
+
+static ssize_t port_ingress_filter_show(
+	struct ksz8895_sysfs_port *port,
+	struct ksz8895_port_attribute *attr,
+	char *buf)
+{
+	int result;
+	int filter;
+
+	result = ksz8895_smi_read(port->ksz8895, port->regbase + 2);
+	if (result < 0)
+		return result;
+
+	filter = result & KSZ8895_INGRESS_VLAN_FILTERING;
+	return scnprintf(buf, PAGE_SIZE, "%d\n", filter);
+}
+
+static ssize_t port_ingress_filter_store(
+	struct ksz8895_sysfs_port *port,
+	struct ksz8895_port_attribute *attr,
+	const char *buf,
+	size_t count)
+{
+	bool filter;
+	int ret;
+
+	ret = kstrtobool(buf, &filter);
+	if (ret)
+		return ret;
+
+	ret = ksz8895_smi_modify(
+		port->ksz8895,
+		port->regbase + 2,
+		KSZ8895_INGRESS_VLAN_FILTERING,
+		filter ? KSZ8895_INGRESS_VLAN_FILTERING : 0
+	);
+	if (ret)
+		return ret;
+
+	return count;
+}
+
+static ssize_t port_insert_tag_show(
+	struct ksz8895_sysfs_port *port,
+	struct ksz8895_port_attribute *attr,
+	char *buf)
+{
+	bool insert;
+	int result;
+
+	result = ksz8895_smi_read(port->ksz8895,
+	                          port->regbase + 0);
+	if (result < 0)
+		return result;
+
+	insert = (result & KSZ8895_TAG_INSERTION) ? 1 : 0;
+	return scnprintf(buf, PAGE_SIZE, "%d\n", insert);
+}
+
+static ssize_t port_insert_tag_store(
+	struct ksz8895_sysfs_port *port,
+	struct ksz8895_port_attribute *attr,
+	const char *buf,
+	size_t count)
+{
+	bool insert;
+	int ret;
+
+	ret = kstrtobool(buf, &insert);
+	if (ret)
+		return ret;
+
+	ret = ksz8895_smi_modify(
+		port->ksz8895,
+		port->regbase + 0,
+		KSZ8895_TAG_INSERTION,
+		insert ? KSZ8895_TAG_INSERTION : 0
+	);
+	if (ret)
+		return ret;
+
+	return count;
+}
+
+static ssize_t port_remove_tag_show(
+	struct ksz8895_sysfs_port *port,
+	struct ksz8895_port_attribute *attr,
+	char *buf)
+{
+	bool remove;
+	int result;
+
+	result = ksz8895_smi_read(port->ksz8895,
+	                          port->regbase + 0);
+	if (result < 0)
+		return result;
+
+	remove = (result & KSZ8895_TAG_REMOVAL) ? 1 : 0;
+	return scnprintf(buf, PAGE_SIZE, "%d\n", remove);
+}
+
+static ssize_t port_remove_tag_store(
+	struct ksz8895_sysfs_port *port,
+	struct ksz8895_port_attribute *attr,
+	const char *buf,
+	size_t count)
+{
+	bool remove;
+	int ret;
+
+	ret = kstrtobool(buf, &remove);
+	if (ret)
+		return ret;
+
+	ret = ksz8895_smi_modify(
+		port->ksz8895,
+		port->regbase + 0,
+		KSZ8895_TAG_REMOVAL,
+		remove ? KSZ8895_TAG_REMOVAL : 0
+	);
+	if (ret)
+		return ret;
+
+	return count;
+}
+
+static ssize_t port_control_show(
+	struct ksz8895_sysfs_port *port,
+	struct ksz8895_port_attribute *attr,
+	char *buf)
+{
+	struct ksz8895_port_control_attribute *control;
+	int ret;
+
+	control = to_ksz8895_port_control(attr);
+
+	ret = ksz8895_smi_read(
+		port->ksz8895,
+		port->regbase + control->regoffset
+	);
+	if (ret < 0)
+		return ret;
+
+	return scnprintf(buf, PAGE_SIZE, "0x%02x\n", ret);
+}
+
+static ssize_t port_control_store(
+	struct ksz8895_sysfs_port *port,
+	struct ksz8895_port_attribute *attr,
+	const char *buf,
+	size_t count)
+{
+	struct ksz8895_port_control_attribute *control;
+	int value;
+	int ret;
+
+	ret = kstrtoint(buf, 10, &value);
+
+	if (value > 0xff)
+		return -EINVAL;
+
+	control = to_ksz8895_port_control(attr);
+	ret = ksz8895_smi_write(
+		port->ksz8895,
+		port->regbase + control->regoffset,
+		(u8) value
+	);
+
+	if (ret)
+		return ret;
+
+	return count;
+}
+
+static struct ksz8895_port_attribute attr_port_vid = __ATTR(
+	vid,
+	(S_IWUSR | S_IRUGO),
+	port_vid_show,
+	port_vid_store
+);
+
+static struct ksz8895_port_attribute attr_port_ingress_filter = __ATTR(
+	ingress_filter,
+	(S_IWUSR | S_IRUGO),
+	port_ingress_filter_show,
+	port_ingress_filter_store
+);
+
+static struct ksz8895_port_attribute attr_port_insert_tag = __ATTR(
+	insert_tag,
+	(S_IWUSR | S_IRUGO),
+	port_insert_tag_show,
+	port_insert_tag_store
+);
+
+static struct ksz8895_port_attribute attr_port_remove_tag = __ATTR(
+	remove_tag,
+	(S_IWUSR | S_IRUGO),
+	port_remove_tag_show,
+	port_remove_tag_store
+);
+
+#define KSZ8895_PORT_CONTROL_ATTR(name, offset) \
+static struct ksz8895_port_control_attribute attr_port_##name = { \
+	.attr = __ATTR( \
+		name, \
+		(S_IWUSR | S_IRUGO), \
+		port_control_show, \
+		port_control_store \
+	), \
+	.regoffset = offset \
+}
+
+KSZ8895_PORT_CONTROL_ATTR(control0, 0);
+KSZ8895_PORT_CONTROL_ATTR(control1, 1);
+KSZ8895_PORT_CONTROL_ATTR(control2, 2);
+KSZ8895_PORT_CONTROL_ATTR(control3, 3);
+KSZ8895_PORT_CONTROL_ATTR(control4, 4);
+KSZ8895_PORT_CONTROL_ATTR(status0, 9);
+KSZ8895_PORT_CONTROL_ATTR(phy_special, 10);
+KSZ8895_PORT_CONTROL_ATTR(linkmd, 11);
+KSZ8895_PORT_CONTROL_ATTR(control5, 12);
+KSZ8895_PORT_CONTROL_ATTR(control6, 13);
+KSZ8895_PORT_CONTROL_ATTR(status1, 14);
+KSZ8895_PORT_CONTROL_ATTR(status2, 15);		/* same register as control 7 */
+KSZ8895_PORT_CONTROL_ATTR(control7, 15);
+
+/* Additional port control registers in the advanced section */
+KSZ8895_PORT_CONTROL_ATTR(control8, 0xa0);
+
+static struct attribute *ksz8895_port_default_attrs[] = {
+	&attr_port_vid.attr,
+	&attr_port_ingress_filter.attr,
+	&attr_port_insert_tag.attr,
+	&attr_port_remove_tag.attr,
+	&attr_port_control0.attr.attr,
+	&attr_port_control1.attr.attr,
+	&attr_port_control2.attr.attr,
+	&attr_port_control3.attr.attr,
+	&attr_port_control4.attr.attr,
+	&attr_port_status0.attr.attr,
+	&attr_port_phy_special.attr.attr,
+	&attr_port_linkmd.attr.attr,
+	&attr_port_control5.attr.attr,
+	&attr_port_control6.attr.attr,
+	&attr_port_status1.attr.attr,
+	&attr_port_status2.attr.attr,
+	&attr_port_control7.attr.attr,
+	&attr_port_control8.attr.attr,
+	NULL
+};
+
+static struct kobj_type ksz8895_port_type = {
+	.sysfs_ops = &ksz8895_port_ops,
+	.release = ksz8895_port_release,
+	.default_attrs = ksz8895_port_default_attrs,
+};

--- a/drivers/net/phy/ksz8895_vlan.c
+++ b/drivers/net/phy/ksz8895_vlan.c
@@ -70,6 +70,20 @@ static int ksz8895_sysfs_vlan_write(struct ksz8895_sysfs_vlan_entry *entry) {
 }
 
 /**
+ * Raw entry access
+ */
+static ssize_t vlan_entry_show(
+	struct ksz8895_sysfs_vlan_entry *entry,
+	struct ksz8895_vlan_attribute *attr,
+	char *buf)
+{
+	return scnprintf(buf, PAGE_SIZE, "valid: %d\nfid: 0x%02x\nmembers: 0x%02x\n",
+		entry->entry.valid,
+		entry->entry.fid,
+		entry->entry.membership);
+}
+
+/**
  * Add a port to the vlan membership list
  */
 static ssize_t vlan_add_port_store(
@@ -137,7 +151,7 @@ static ssize_t vlan_ports_store(
 	if (ret)
 		return ret;
 
-	return 0;
+	return count;
 }
 
 static ssize_t vlan_remove_port_store(
@@ -241,6 +255,13 @@ static ssize_t vlan_valid_store(
 	return count;
 }
 
+static struct ksz8895_vlan_attribute attr_vlan_entry = __ATTR(
+	entry,
+	S_IRUGO,
+	vlan_entry_show,
+	NULL
+);
+
 static struct ksz8895_vlan_attribute attr_vlan_add_port = __ATTR(
 	add_port,
 	S_IWUSR,
@@ -277,6 +298,7 @@ static struct ksz8895_vlan_attribute attr_vlan_valid = __ATTR(
 );
 
 static struct attribute *ksz8895_vlan_default_attrs[] = {
+	&attr_vlan_entry.attr,
 	&attr_vlan_add_port.attr,
 	&attr_vlan_ports.attr,
 	&attr_vlan_remove_port.attr,

--- a/drivers/net/phy/ksz8895_vlan.c
+++ b/drivers/net/phy/ksz8895_vlan.c
@@ -1,0 +1,293 @@
+/**
+ * vlan specific kobject management stuff, include directly in ksz8895.c
+ */
+
+struct ksz8895_sysfs_vlan_entry {
+	struct kobject kobj;
+	struct ksz8895_vlan_entry entry;
+	struct ksz8895_data *ksz8895;
+};
+
+#define to_ksz8895_sysfs_vlan_entry(vlan) container_of(vlan, struct ksz8895_sysfs_vlan_entry, kobj)
+
+struct ksz8895_vlan_attribute {
+	struct attribute attr;
+	ssize_t (*show)(struct ksz8895_sysfs_vlan_entry *,
+	                struct ksz8895_vlan_attribute *,
+					char *);
+	ssize_t (*store)(struct ksz8895_sysfs_vlan_entry *,
+	                 struct ksz8895_vlan_attribute *,
+					 const char *,
+					 size_t);
+};
+
+#define to_ksz8895_vlan_attribute(vlan) container_of(vlan, struct ksz8895_vlan_attribute, attr)
+
+/* free memory associated with vlan entry */
+static void ksz8895_vlan_release(struct kobject *kobj) {
+	struct ksz8895_sysfs_vlan_entry *entry = to_ksz8895_sysfs_vlan_entry(kobj);
+	kfree(entry);
+}
+
+/* show a vlan entry */
+static ssize_t ksz8895_vlan_show(struct kobject *kobj, struct attribute *attr, char *buf) {
+	struct ksz8895_sysfs_vlan_entry *entry = to_ksz8895_sysfs_vlan_entry(kobj);
+	struct ksz8895_vlan_attribute *vlan_attr = to_ksz8895_vlan_attribute(attr);
+
+	if (!vlan_attr->show)
+		return -EIO;
+
+	return vlan_attr->show(entry, vlan_attr, buf);
+}
+
+/* modify a vlan entry */
+static ssize_t ksz8895_vlan_store(
+	struct kobject *kobj,
+	struct attribute *attr,
+	const char *buf,
+	size_t count)
+{
+	struct ksz8895_sysfs_vlan_entry *entry = to_ksz8895_sysfs_vlan_entry(kobj);
+	struct ksz8895_vlan_attribute *vlan_attr = to_ksz8895_vlan_attribute(attr);
+
+	if (!vlan_attr->store)
+		return -EIO;
+
+	return vlan_attr->store(entry, vlan_attr, buf, count);
+}
+
+static const struct sysfs_ops ksz8895_vlan_ops = {
+	.show = ksz8895_vlan_show,
+	.store = ksz8895_vlan_store,
+};
+
+static int ksz8895_sysfs_vlan_write(struct ksz8895_sysfs_vlan_entry *entry) {
+	return ksz8895_write_vlan_entry(
+		entry->ksz8895,
+		&entry->entry,
+		entry->entry.valid
+	);
+}
+
+/**
+ * Add a port to the vlan membership list
+ */
+static ssize_t vlan_add_port_store(
+	struct ksz8895_sysfs_vlan_entry *entry,
+	struct ksz8895_vlan_attribute *attr,
+	const char *buf,
+	size_t count)
+{
+	unsigned int port;
+	int ret;
+
+	ret = kstrtouint(buf, 10, &port);
+	if (ret)
+		return ret;
+
+	if (port < 1 || port > 5)
+		return -EINVAL;
+
+	dev_info(entry->ksz8895->dev,
+		"add port request for %d to vlan %d\n",
+		port, entry->entry.id);
+
+	/* logical 1-indexed ports are 0-indexed in hardware */
+	port -= 1;
+
+	entry->entry.membership |= (1 << port);
+
+	ret = ksz8895_sysfs_vlan_write(entry);
+	if (ret)
+		return ret;
+
+	return count;
+}
+
+/**
+ * View or modify the ports as an integer, use add/remove instead for simplicity
+ */
+static ssize_t vlan_ports_show(
+	struct ksz8895_sysfs_vlan_entry *entry,
+	struct ksz8895_vlan_attribute *attr,
+	char *buf)
+{
+	return scnprintf(buf, PAGE_SIZE, "0x%02x\n", entry->entry.membership);
+}
+
+static ssize_t vlan_ports_store(
+	struct ksz8895_sysfs_vlan_entry *entry,
+	struct ksz8895_vlan_attribute *attr,
+	const char *buf,
+	size_t count)
+{
+	unsigned int ports;
+	int ret;
+
+	ret = kstrtouint(buf, 10, &ports);
+	if (ret)
+		return ret;
+
+	/* 5 bit fields for 5 ports */
+	if (ports > 0x1f)
+		return -EINVAL;
+
+	entry->entry.membership = ports;
+	ret = ksz8895_sysfs_vlan_write(entry);
+	if (ret)
+		return ret;
+
+	return 0;
+}
+
+static ssize_t vlan_remove_port_store(
+	struct ksz8895_sysfs_vlan_entry *entry,
+	struct ksz8895_vlan_attribute *attr,
+	const char *buf,
+	size_t count)
+{
+	unsigned int port;
+	int ret;
+
+	ret = kstrtouint(buf, 10, &port);
+	if (ret)
+		return ret;
+
+	if (port < 1 || port > 5)
+		return -EINVAL;
+
+	dev_info(entry->ksz8895->dev,
+		"remove port request for %d to vlan %d\n",
+		port, entry->entry.id);
+
+	/* logical 1-indexed ports are 0-indexed in hardware */
+	port -= 1;
+
+	entry->entry.membership &= ~(1 << port);
+
+	ret = ksz8895_sysfs_vlan_write(entry);
+	if (ret)
+		return ret;
+
+	return count;
+}
+
+static ssize_t vlan_fid_show(
+	struct ksz8895_sysfs_vlan_entry *entry,
+	struct ksz8895_vlan_attribute *attr,
+	char *buf)
+{
+	return scnprintf(buf, PAGE_SIZE, "0x%02x\n", entry->entry.fid);
+}
+
+static ssize_t vlan_fid_store(
+	struct ksz8895_sysfs_vlan_entry *entry,
+	struct ksz8895_vlan_attribute *attr,
+	const char *buf,
+	size_t count)
+{
+	unsigned int fid;
+	int ret;
+
+	ret = kstrtouint(buf, 10, &fid);
+	if (ret)
+		return ret;
+
+	if (fid > KSZ8895_MAXIMUM_VLAN_FID)
+		return -EINVAL;
+
+	dev_info(entry->ksz8895->dev, "vlan %d: change fid %d -> %d\n",
+		entry->entry.id, entry->entry.fid, fid);
+
+	entry->entry.fid = (u8) fid;
+
+	ret = ksz8895_sysfs_vlan_write(entry);
+	if (ret)
+		return ret;
+
+	return count;
+}
+
+static ssize_t vlan_valid_show(
+	struct ksz8895_sysfs_vlan_entry *entry,
+	struct ksz8895_vlan_attribute *attr,
+	char *buf)
+{
+	return scnprintf(buf, PAGE_SIZE, "%d\n", entry->entry.valid);
+}
+
+static ssize_t vlan_valid_store(
+	struct ksz8895_sysfs_vlan_entry *entry,
+	struct ksz8895_vlan_attribute *attr,
+	const char *buf,
+	size_t count)
+{
+	bool valid;
+	int ret;
+
+	ret = kstrtobool(buf, &valid);
+	if (ret)
+		return ret;
+
+	dev_info(entry->ksz8895->dev, "vlan %d: change valid %d -> %d\n",
+		entry->entry.id, entry->entry.valid, valid);
+
+	entry->entry.valid = valid;
+
+	ret = ksz8895_sysfs_vlan_write(entry);
+	if (ret)
+		return ret;
+
+	return count;
+}
+
+static struct ksz8895_vlan_attribute attr_vlan_add_port = __ATTR(
+	add_port,
+	S_IWUSR,
+	NULL,
+	vlan_add_port_store
+);
+
+static struct ksz8895_vlan_attribute attr_vlan_ports = __ATTR(
+	ports,
+	(S_IWUSR | S_IRUGO),
+	vlan_ports_show,
+	vlan_ports_store
+);
+
+static struct ksz8895_vlan_attribute attr_vlan_remove_port = __ATTR(
+	remove_port,
+	S_IWUSR,
+	NULL,
+	vlan_remove_port_store
+);
+
+static struct ksz8895_vlan_attribute attr_vlan_fid = __ATTR(
+	fid,
+	(S_IWUSR | S_IRUGO),
+	vlan_fid_show,
+	vlan_fid_store
+);
+
+static struct ksz8895_vlan_attribute attr_vlan_valid = __ATTR(
+	valid,
+	(S_IWUSR | S_IRUGO),
+	vlan_valid_show,
+	vlan_valid_store
+);
+
+static struct attribute *ksz8895_vlan_default_attrs[] = {
+	&attr_vlan_add_port.attr,
+	&attr_vlan_ports.attr,
+	&attr_vlan_remove_port.attr,
+	&attr_vlan_fid.attr,
+	&attr_vlan_valid.attr,
+	NULL
+};
+
+static struct kobj_type ksz8895_vlan_type = {
+	.sysfs_ops = &ksz8895_vlan_ops,
+	.release = ksz8895_vlan_release,
+	.default_attrs = ksz8895_vlan_default_attrs,
+};
+


### PR DESCRIPTION
Hi, I've added a sysfs interface for controlling general configuration, vlan details, and port configurations for most (but not all) registers on the device. New registers can be added easily as necessary. I've also added an example DTS fragment to suggest how to incorporate the device. This was built for a 4.14.78 kernel.